### PR TITLE
Domain server http port in shmem

### DIFF
--- a/src/AppDelegate.cpp
+++ b/src/AppDelegate.cpp
@@ -256,7 +256,8 @@ void AppDelegate::stopScriptedAssignment(const QUuid& scriptID) {
 
 void AppDelegate::requestDomainServerID() {
     // ask the domain-server for its ID so we can update the accessible name
-    QUrl domainIDURL = DOMAIN_SERVER_BASE_URL + "/id";
+    emit domainAddressChanged();
+    QUrl domainIDURL = GlobalData::getInstance().getDomainServerBaseUrl() + "/id";
     
     qDebug() << "Requesting domain server ID from" << domainIDURL.toString();
     
@@ -358,7 +359,7 @@ void AppDelegate::sendNewIDToDomainServer() {
     // it is possible this will require authentication - if so there's nothing we can do about it for now
     QString settingsJSON = "{\"metaverse\": { \"id\": \"%1\", \"automatic_networking\": \"full\", \"local_port\": \"0\" } }";
 
-    QNetworkRequest settingsRequest(DOMAIN_SERVER_BASE_URL + "/settings.json");
+    QNetworkRequest settingsRequest(GlobalData::getInstance().getDomainServerBaseUrl() + "/settings.json");
     settingsRequest.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     
     QNetworkReply* settingsReply = _manager->post(settingsRequest, settingsJSON.arg(_domainServerID).toLocal8Bit());

--- a/src/AppDelegate.h
+++ b/src/AppDelegate.h
@@ -22,8 +22,6 @@
 
 class BackgroundProcess;
 
-const QString DOMAIN_SERVER_BASE_URL = "http://localhost:40100";
-
 class AppDelegate : public QApplication
 {
     Q_OBJECT

--- a/src/GlobalData.cpp
+++ b/src/GlobalData.cpp
@@ -68,6 +68,8 @@ GlobalData::GlobalData() {
 
     // allow user to override path to binaries so that they can run their own builds
     _hifiBuildDirectory = "";
+
+    _domainServerBaseUrl = "http://localhost:40100";
 }
 
 

--- a/src/GlobalData.h
+++ b/src/GlobalData.h
@@ -11,7 +11,6 @@
 
 #include <QString>
 #include <QHash>
-#include <QDebug>
 
 class GlobalData {
 public:

--- a/src/GlobalData.h
+++ b/src/GlobalData.h
@@ -11,6 +11,7 @@
 
 #include <QString>
 #include <QHash>
+#include <QDebug>
 
 class GlobalData {
 public:
@@ -37,6 +38,9 @@ public:
 
     void setHifiBuildDirectory(const QString hifiBuildDirectory);
     bool isGetHifiBuildDirectorySet() { return _hifiBuildDirectory != ""; }
+
+    void setDomainServerBaseUrl(const QString domainServerBaseUrl) { _domainServerBaseUrl = domainServerBaseUrl; }
+    QString getDomainServerBaseUrl() { return _domainServerBaseUrl; }
 
 private:
     GlobalData();
@@ -65,6 +69,8 @@ private:
     QString _domainServerExecutable;
 
     QHash<QString, int> _availableAssignmentTypes;
+
+    QString _domainServerBaseUrl;
 };
 
 #endif

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -37,6 +37,7 @@ private slots:
     void addAssignment();
     void openSettings();
     void updateServerAddressLabel();
+    void updateServerBaseUrl();
     void toggleShareButtonText();
     void handleShareButton();
     void showContentSetPage();

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -17,6 +17,7 @@
 #include <QTabWidget>
 #include <QVBoxLayout>
 #include <QWidget>
+#include <QSharedMemory>
 
 
 #include "SvgButton.h"
@@ -28,6 +29,7 @@ public:
     
     void setRequirementsLastChecked(const QString& lastCheckedDateTime);
     QTabWidget* getLogsWidget() { return _logsWidget; }
+    bool getLocalServerPortFromSharedMemory(const QString key, QSharedMemory*& sharedMem, quint16& localPort);
 
 protected:
     virtual void paintEvent(QPaintEvent*);

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -61,6 +61,8 @@ private:
     QTabWidget* _logsWidget;
     QVBoxLayout* _assignmentLayout;
     QScrollArea* _assignmentScrollArea;
+
+    QSharedMemory* _localHttpPortSharedMem; // memory shared with domain server
 };
 
 #endif


### PR DESCRIPTION
Get the local domain-server's http port out of shared memory (if possible), rather than assuming the default.
